### PR TITLE
Fix syntax for conditional and tag push in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,10 +197,10 @@ jobs:
         with:
           ref: ${{ env.VERSION }}
       - name: Update major tag
-        if: steps.get-semver.outputs.major != '0'
+        if: ${{ steps.get-semver.outputs.major != '0' }}
         run: |
-          git push -f origin "refs/tags/$env:VERSION:refs/tags/${{ steps.get-semver.outputs.major }}"
+          git push -f origin "refs/tags/${{ env.VERSION }}:refs/tags/${{ steps.get-semver.outputs.major }}"
       - name: Update minor tag
-        if: steps.get-semver.outputs.minor != '0.0'
+        if: ${{ steps.get-semver.outputs.minor != '0.0' }}
         run: |
-          git push -f origin "refs/tags/$env:VERSION:refs/tags/${{ steps.get-semver.outputs.minor }}"
+          git push -f origin "refs/tags/${{ env.VERSION }}:refs/tags/${{ steps.get-semver.outputs.minor }}"


### PR DESCRIPTION
Corrects the syntax for 'if' conditions and the git push command in the release.yml workflow to use proper GitHub Actions expressions and environment variable references.