### PR TITLE
Add local testing setup documentation

### DIFF
--- a/.github/DRAFT_README.md
+++ b/.github/DRAFT_README.md
@@ -164,7 +164,8 @@ INPUT_EXCLUDE-PATTERNS=
 }
 ```
 
-Replace the values with actual pull request data from your repository. You can get this information from:
+Replace the values with actual pull request data from your repository. You can
+get this information from:
 
 - GitHub API: `GET /repos/{owner}/{repo}/pulls/{pull_number}`
 - An existing pull request in your repository

--- a/.github/DRAFT_README.md
+++ b/.github/DRAFT_README.md
@@ -140,8 +140,6 @@ INPUT_GITHUB-TOKEN=your_github_token
 INPUT_EXCLUDE-PATTERNS=
 ```
 
-**Note**: `INPUT_GITHUB-TOKEN` must have the same value as `GITHUB_TOKEN` for the action inputs to work properly.
-
 **Step 2: Create a `test-pr-event.json` file**
 
 ```json

--- a/.github/DRAFT_README.md
+++ b/.github/DRAFT_README.md
@@ -129,17 +129,52 @@ jobs:
 
 You can test the action locally using the `@github/local-action` utility:
 
-```bash
-npx @github/local-action . src/main.ts .env
-```
-
-Create a `.env` file with the necessary environment variables:
+**Step 1: Create a `.env` file**
 
 ```env
 GITHUB_TOKEN=your_github_token
 GITHUB_REPOSITORY=owner/repo
 GITHUB_EVENT_NAME=pull_request
-GITHUB_EVENT_PATH=path/to/event.json
+GITHUB_EVENT_PATH=test-pr-event.json
+INPUT_GITHUB-TOKEN=your_github_token
+INPUT_EXCLUDE-PATTERNS=
+```
+
+**Note**: `INPUT_GITHUB-TOKEN` must have the same value as `GITHUB_TOKEN` for the action inputs to work properly.
+
+**Step 2: Create a `test-pr-event.json` file**
+
+```json
+{
+  "pull_request": {
+    "number": 123,
+    "head": {
+      "sha": "abc123def456...",
+      "ref": "feature-branch"
+    },
+    "base": {
+      "sha": "789012efg345...",
+      "ref": "main"
+    }
+  },
+  "repository": {
+    "name": "repo-name",
+    "owner": {
+      "login": "owner-name"
+    }
+  }
+}
+```
+
+Replace the values with actual pull request data from your repository. You can get this information from:
+
+- GitHub API: `GET /repos/{owner}/{repo}/pulls/{pull_number}`
+- An existing pull request in your repository
+
+**Step 3: Run the local test**
+
+```bash
+npx @github/local-action . src/main.ts .env
 ```
 
 ## How It Works

--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,6 @@ __tests__/runner/*
 # IDE files
 .idea
 *.code-workspace
+
+# Test files
+test-pr-event.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,10 +102,44 @@ Create `.env` file with:
 GITHUB_TOKEN=your_github_token
 GITHUB_REPOSITORY=owner/repo
 GITHUB_EVENT_NAME=pull_request
-GITHUB_EVENT_PATH=path/to/event.json
+GITHUB_EVENT_PATH=test-pr-event.json
+INPUT_GITHUB-TOKEN=your_github_token
+INPUT_EXCLUDE-PATTERNS=
 ```
 
-Then run: `npm run local-action`
+Note: `INPUT_GITHUB-TOKEN` must have the same value as `GITHUB_TOKEN` for the action inputs to work properly.
+
+Create `test-pr-event.json` file with PR event data:
+
+```json
+{
+  "pull_request": {
+    "number": 123,
+    "head": {
+      "sha": "abc123def456...",
+      "ref": "feature-branch"
+    },
+    "base": {
+      "sha": "789012efg345...",
+      "ref": "main"
+    }
+  },
+  "repository": {
+    "name": "repo-name",
+    "owner": {
+      "login": "owner-name"
+    }
+  }
+}
+```
+
+Replace the values with actual PR data from your repository. You can get this information from GitHub API or an existing PR.
+
+Run the local test:
+
+```bash
+npx @github/local-action . src/main.ts .env
+```
 
 ### Code Quality
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,8 +107,6 @@ INPUT_GITHUB-TOKEN=your_github_token
 INPUT_EXCLUDE-PATTERNS=
 ```
 
-Note: `INPUT_GITHUB-TOKEN` must have the same value as `GITHUB_TOKEN` for the action inputs to work properly.
-
 Create `test-pr-event.json` file with PR event data:
 
 ```json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,7 +131,8 @@ Create `test-pr-event.json` file with PR event data:
 }
 ```
 
-Replace the values with actual PR data from your repository. You can get this information from GitHub API or an existing PR.
+Replace the values with actual PR data from your repository. You can get this
+information from GitHub API or an existing PR.
 
 Run the local test:
 

--- a/README.md
+++ b/README.md
@@ -170,8 +170,6 @@ INPUT_GITHUB-TOKEN=your_github_token
 INPUT_EXCLUDE-PATTERNS=
 ```
 
-**Note**: `INPUT_GITHUB-TOKEN` must have the same value as `GITHUB_TOKEN` for the action inputs to work properly.
-
 2. Create a `test-pr-event.json` file with pull request event data:
 
 ```json

--- a/README.md
+++ b/README.md
@@ -194,7 +194,9 @@ INPUT_EXCLUDE-PATTERNS=
 }
 ```
 
-Replace the values with actual pull request data from your repository. You can get this information from:
+Replace the values with actual pull request data from your repository. You can
+get this information from:
+
 - GitHub API: `GET /repos/{owner}/{repo}/pulls/{pull_number}`
 - An existing pull request in your repository
 
@@ -204,7 +206,8 @@ Replace the values with actual pull request data from your repository. You can g
 npx @github/local-action . src/main.ts .env
 ```
 
-This will execute the action locally and show you the results without needing to push changes to GitHub.
+This will execute the action locally and show you the results without needing to
+push changes to GitHub.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,59 @@ This action:
 4. Reports any files containing these markers
 5. Fails the workflow if conflicts are detected
 
+## Local Testing
+
+You can test this action locally using the `@github/local-action` tool:
+
+1. Create a `.env` file with your GitHub credentials:
+
+```env
+GITHUB_TOKEN=your_github_token
+GITHUB_REPOSITORY=owner/repo
+GITHUB_EVENT_NAME=pull_request
+GITHUB_EVENT_PATH=test-pr-event.json
+INPUT_GITHUB-TOKEN=your_github_token
+INPUT_EXCLUDE-PATTERNS=
+```
+
+**Note**: `INPUT_GITHUB-TOKEN` must have the same value as `GITHUB_TOKEN` for the action inputs to work properly.
+
+2. Create a `test-pr-event.json` file with pull request event data:
+
+```json
+{
+  "pull_request": {
+    "number": 123,
+    "head": {
+      "sha": "abc123def456...",
+      "ref": "feature-branch"
+    },
+    "base": {
+      "sha": "789012efg345...",
+      "ref": "main"
+    }
+  },
+  "repository": {
+    "name": "repo-name",
+    "owner": {
+      "login": "owner-name"
+    }
+  }
+}
+```
+
+Replace the values with actual pull request data from your repository. You can get this information from:
+- GitHub API: `GET /repos/{owner}/{repo}/pulls/{pull_number}`
+- An existing pull request in your repository
+
+3. Run the local test:
+
+```bash
+npx @github/local-action . src/main.ts .env
+```
+
+This will execute the action locally and show you the results without needing to push changes to GitHub.
+
 ## Contributing
 
 Contributions are welcome! Please feel free to submit a Pull Request.


### PR DESCRIPTION
## Summary
- Add test-pr-event.json to .gitignore for local testing files
- Enable local testing with @github/local-action tool

## Test plan
- [x] Verified local testing works with `npx @github/local-action . src/main.ts .env`
- [x] Confirmed test-pr-event.json is properly ignored by git
- [x] Tested with real PR data from the repository

## Additional Notes
This change improves the development experience by allowing contributors to test the GitHub Action locally before pushing changes. The test-pr-event.json file contains PR event data needed for local testing but should not be committed to the repository.

🤖 Generated with [Claude Code](https://claude.ai/code)