### PR TITLE
Add .serena to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ __tests__/runner/*
 
 # Test files
 test-pr-event.json
+
+# Serena directory
+.serena


### PR DESCRIPTION
## Summary
- Added  directory to  to exclude Serena-specific files from version control

## Context
The  directory contains Serena MCP server configuration and memory files that should not be tracked in the repository.

## Changes
- Updated  to include  entry