### PR TITLE
docs: Add Limitations section to README files

### DIFF
--- a/.github/DRAFT_README.md
+++ b/.github/DRAFT_README.md
@@ -190,6 +190,12 @@ This action:
 4. Reports any files containing these markers
 5. Fails the workflow if conflicts are detected
 
+## Limitations
+
+- **Git LFS Files**: Conflict markers in Git LFS-managed files cannot be detected by default. This is due to a known Git LFS issue ([git-lfs/git-lfs#6006](https://github.com/git-lfs/git-lfs/pull/6006)) where LFS pointer files are returned instead of actual file content when conflicts occur.
+
+- **Custom Conflict Markers**: This action may not detect conflicts if you have customized Git's conflict marker style or size through `merge.conflictStyle` or `merge.conflictMarkerSize` settings. The action only detects the standard 7-character conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`).
+
 ## Contributing
 
 Contributions are welcome! Please feel free to submit a Pull Request.

--- a/.github/DRAFT_README.md
+++ b/.github/DRAFT_README.md
@@ -192,9 +192,16 @@ This action:
 
 ## Limitations
 
-- **Git LFS Files**: Conflict markers in Git LFS-managed files cannot be detected by default. This is due to a known Git LFS issue ([git-lfs/git-lfs#6006](https://github.com/git-lfs/git-lfs/pull/6006)) where LFS pointer files are returned instead of actual file content when conflicts occur.
+- **Git LFS Files**: Conflict markers in Git LFS-managed files cannot be
+  detected by default. This is due to a known Git LFS issue
+  ([git-lfs/git-lfs#6006](https://github.com/git-lfs/git-lfs/pull/6006)) where
+  LFS pointer files are returned instead of actual file content when conflicts
+  occur.
 
-- **Custom Conflict Markers**: This action may not detect conflicts if you have customized Git's conflict marker style or size through `merge.conflictStyle` or `merge.conflictMarkerSize` settings. The action only detects the standard 7-character conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`).
+- **Custom Conflict Markers**: This action may not detect conflicts if you have
+  customized Git's conflict marker style or size through `merge.conflictStyle`
+  or `merge.conflictMarkerSize` settings. The action only detects the standard
+  7-character conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -190,6 +190,12 @@ This action:
 4. Reports any files containing these markers
 5. Fails the workflow if conflicts are detected
 
+## Limitations
+
+- **Git LFS Files**: Conflict markers in Git LFS-managed files cannot be detected by default. This is due to a known Git LFS issue ([git-lfs/git-lfs#6006](https://github.com/git-lfs/git-lfs/pull/6006)) where LFS pointer files are returned instead of actual file content when conflicts occur.
+
+- **Custom Conflict Markers**: This action may not detect conflicts if you have customized Git's conflict marker style or size through `merge.conflictStyle` or `merge.conflictMarkerSize` settings. The action only detects the standard 7-character conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`).
+
 ## Contributing
 
 Contributions are welcome! Please feel free to submit a Pull Request.

--- a/README.md
+++ b/README.md
@@ -192,9 +192,16 @@ This action:
 
 ## Limitations
 
-- **Git LFS Files**: Conflict markers in Git LFS-managed files cannot be detected by default. This is due to a known Git LFS issue ([git-lfs/git-lfs#6006](https://github.com/git-lfs/git-lfs/pull/6006)) where LFS pointer files are returned instead of actual file content when conflicts occur.
+- **Git LFS Files**: Conflict markers in Git LFS-managed files cannot be
+  detected by default. This is due to a known Git LFS issue
+  ([git-lfs/git-lfs#6006](https://github.com/git-lfs/git-lfs/pull/6006)) where
+  LFS pointer files are returned instead of actual file content when conflicts
+  occur.
 
-- **Custom Conflict Markers**: This action may not detect conflicts if you have customized Git's conflict marker style or size through `merge.conflictStyle` or `merge.conflictMarkerSize` settings. The action only detects the standard 7-character conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`).
+- **Custom Conflict Markers**: This action may not detect conflicts if you have
+  customized Git's conflict marker style or size through `merge.conflictStyle`
+  or `merge.conflictMarkerSize` settings. The action only detects the standard
+  7-character conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`).
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

This PR adds a Limitations section to both README files documenting known detection limitations.

## Changes

- Added Limitations section to  and 
- Documented Git LFS file detection limitation (referencing git-lfs/git-lfs#6006)
- Documented custom conflict marker configuration detection limitation

## Context

The action cannot detect conflict markers in:
1. **Git LFS files**: LFS returns pointer files instead of actual content during conflicts
2. **Custom conflict markers**: When Git's  or  settings are customized

These limitations are important for users to understand to avoid false negatives in conflict detection.