### PR TITLE
fix: Address zizmor security findings in GitHub Actions workflows

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -33,6 +33,8 @@ jobs:
       - name: Checkout
         id: checkout
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         id: setup-node

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
       - name: Checkout
         id: checkout
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         id: setup-node
@@ -57,6 +59,8 @@ jobs:
       - name: Checkout
         id: checkout
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Test Local Action
         id: test-action

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,6 +31,8 @@ jobs:
       - name: Checkout
         id: checkout
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
         id: initialize

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -63,6 +63,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       # Add any setup steps before running the `github/codeql-action/init` action.
       # This includes steps like installing compilers or runtimes (`actions/setup-node`

--- a/.github/workflows/licensed.yml
+++ b/.github/workflows/licensed.yml
@@ -16,7 +16,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 defaults:
   run:
@@ -26,6 +26,8 @@ jobs:
   licensed:
     name: Check Licenses
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -28,6 +28,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Node.js
         id: setup-node

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -27,6 +26,8 @@ jobs:
     name: Paths Filter
     if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       package_json: ${{ steps.filter.outputs.package_json }}
     steps:
@@ -44,6 +45,8 @@ jobs:
       ${{ github.event_name == 'pull_request' &&
       needs.paths-filter.outputs.package_json == 'true' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       version_changed: ${{ steps.check-version.outputs.version_changed }}
     steps:
@@ -81,6 +84,9 @@ jobs:
       github.event.pull_request.base.ref == 'main') || github.event_name ==
       'workflow_dispatch' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
@@ -97,6 +103,9 @@ jobs:
     needs: update-draft
     if: ${{ github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     concurrency:
       group: ${{ github.workflow }}
       cancel-in-progress: true
@@ -156,6 +165,8 @@ jobs:
     needs: [update-draft, paths-filter, check-version]
     environment: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     concurrency:
       group: ${{ github.workflow }}
       cancel-in-progress: false
@@ -171,6 +182,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: main
+          persist-credentials: false
       - name: Validate version in package.json
         run: |
           $packageJson = Get-Content -Path $env:PACKAGE_JSON_PATH -Raw | ConvertFrom-Json


### PR DESCRIPTION
## Summary
This PR addresses security findings from zizmor that were introduced in super-linter v8.1.0 (PR #84).

## Changes
- Add `persist-credentials: false` to checkout actions where credentials are not needed
- Move excessive permissions from workflow level to job level in `release.yml`
- Set minimal required permissions for each job
- Keep credentials for checkouts that legitimately need them (pushing commits, tags, etc.)

## Security Impact
- **Fixed**: 2 high severity issues (excessive workflow-level permissions)
- **Fixed**: 7 medium severity issues (unnecessary credential persistence)
- **Remaining**: 3 medium severity warnings for checkouts that need credentials (intentional)
- **Remaining**: 2 informational template injection warnings (low risk, existing code)

## Related Issues
Fixes the GITHUB_ACTIONS_ZIZMOR check failure in #84

## Test Plan
- [x] Run zizmor locally to verify fixes
- [ ] Verify all workflows still function correctly
- [ ] Confirm PR #84 checks pass after merging this fix